### PR TITLE
Change Construction Of Krab [Breaking Change]

### DIFF
--- a/krab_test.go
+++ b/krab_test.go
@@ -7,6 +7,7 @@ import (
 	ci "github.com/libp2p/go-libp2p-crypto"
 
 	"github.com/RTradeLtd/krab"
+	badger "github.com/ipfs/go-ds-badger"
 )
 
 const (
@@ -18,14 +19,18 @@ const (
 func TestKrab(t *testing.T) {
 	defer func() {
 		if err := os.RemoveAll(dsPath); err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 	}()
-	km, err := krab.NewKeystore(krab.Opts{Passphrase: passphrase, DSPath: dsPath, ReadOnly: false})
+	ds, err := badger.NewDatastore(dsPath, &badger.DefaultOptions)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer km.Close()
+	defer ds.Close()
+	km, err := krab.NewKeystore(ds, passphrase)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// this should fail
 	if has, err := km.Has(testKeyName); err == nil {
 		t.Fatal("key was found when it shouldn't have been")


### PR DESCRIPTION
Don't create an internal datastore, as the choice of badger may not be appropriate for all systems. Instead, provide a datastore within the constructor, and create a namespace wrapped datastore. 

